### PR TITLE
replace netcat to netcat-openbsd in Dockerfile (#1950)

### DIFF
--- a/deploy/kubernetes/docker/base/debian/Dockerfile
+++ b/deploy/kubernetes/docker/base/debian/Dockerfile
@@ -20,5 +20,5 @@ ARG BASE_IMAGE=eclipse-temurin:11-jdk
 FROM ${BASE_IMAGE}
 
 RUN apt-get update && \
-    apt-get install -y zlib1g zlib1g-dev lzop lsof netcat dnsutils less procps iputils-ping && \
+    apt-get install -y zlib1g zlib1g-dev lzop lsof netcat-openbsd dnsutils less procps iputils-ping && \
     apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What changes were proposed in this pull request? Replace netcat to netcat-openbsd in Dockerfile.

### Why are the changes needed?
On Debian, netcat isn’t a package, as two “variations” of netcat exist in the package repository. https://github.com/apache/incubator-uniffle/actions/runs/10073085326/job/27848719086?pr=1948


### Does this PR introduce _any_ user-facing change? No.

### How was this patch tested?
CI

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. Contributor guidelines:
   https://github.com/apache/incubator-uniffle/blob/master/CONTRIBUTING.md
3. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

No.

### How was this patch tested?

(Please test your changes, and provide instructions on how to test it:
  1. If you add a feature or fix a bug, add a test to cover your changes. 
  2. If you fix a flaky test, repeat it for many times to prove it works.)
